### PR TITLE
ABI-safe tf_prefix cache

### DIFF
--- a/include/robot_state_publisher/joint_state_listener.h
+++ b/include/robot_state_publisher/joint_state_listener.h
@@ -87,8 +87,7 @@ protected:
   MimicMap mimic_;
   bool use_tf_static_;
   bool ignore_timestamp_;
-  std::string tf_prefix_;
-  bool tf_prefix_cached_;
+
 };
 }
 


### PR DESCRIPTION
To comply ABI policy, adding new field to existing classes are not allowed.
Instead, I added a thread-safe global map to keep the parameter, with the key being class instance pointer.